### PR TITLE
Misrendered abstract on `kuleshov18a.html`

### DIFF
--- a/_posts/2018-06-07-kuleshov18a.md
+++ b/_posts/2018-06-07-kuleshov18a.md
@@ -3,26 +3,26 @@ title: Conformal prediction in manifold learning
 abstract: 'The paper presents a geometrically motivated view on conformal prediction
   applied to nonlinear multi-output regression tasks for obtaining valid measure of
   accuracy of Manifold Learning Regression algorithms. A considered regression task
-  is to estimate an unknown smooth mapping $\mathbff$ from $q$-dimensional inputs
-  $\mathbfx ∈\mathbfX$ to $m$-dimensional outputs $\mathbfy = \mathbff(\mathbfx)$
-  based on training dataset $\mathbfZ_(n)$ consisting of “input-output” pairs ${Z_i
-  = (\mathbfx_i, \mathbfy_i = \mathbff(\mathbfx_i))^\textrmT, i = 1, 2, ..., n}$.
+  is to estimate an unknown smooth mapping $\mathbf{f}$ from $q$-dimensional inputs
+  $\mathbf{x}\in \mathbf{X}$ to $m$-dimensional outputs $\mathbf{y} = \mathbf{f}(\mathbf{x})$
+  based on training dataset $\mathbf{Z}_{(n)}$ consisting of ``input-output'' pairs $\{Z_i
+  = (\mathbf{x}_i, \mathbf{y}_i = \mathbf{f}(\mathbf{x}_i))^{\mr{T}}, i = 1, 2, \ldots , n\}$.
   Manifold Learning Regression (MLR) algorithm solves this task using Manifold learning
-  technique. At first, unknown $q$-dimensional Regression manifold $\mathbfM(\mathbff)
-  = {(\mathbfx,\mathbff(\mathbfx))^\textrmT∈\mathrmR^q+m: \mathbfx ∈\mathbfX ⊂\mathrmR^q}$,
+  technique. At first, unknown $q$-dimensional Regression manifold $\mathbf{M}(\mathbf{f})
+  = \{(\mathbf{x}, \mathbf{f}(\mathbf{x}))^{\mr{T}}\in\mathbb{R}^{q+m}: \mathbf{x}\in \mathbf{X}\subset \mathbb{R}^{q} \}$,
   embedded in ambient $(q+m)$-dimensional space, is estimated from the training data
-  $\mathbfZ_(n)$, sampled from this manifold. The constructed estimator $\mathbfM_\textMLR$,
-  which is also $q$-dimensional manifold embedded in ambient space $\textrmR^q+m$,
-  is close to $\mathbfM$ in terms of Hausdorff distance. After that, an estimator
-  $\mathbff_\textMLR$ of the unknown function $\mathbff$, mapping arbitrary input
-  $\mathbfx ∈\mathbfX$ to output $\mathbff_\textrmMLR(\mathbfx)$, is constructed as
-  the solution to the equation $\mathbfM(\mathbff_\textrmMLR) = \mathbfM_\textMLR$.
+  $\mathbf{Z}_{(n)}$, sampled from this manifold. The constructed estimator $\mathbf{M}_{MLR}$,
+  which is also $q$-dimensional manifold embedded in ambient space $\mathbb{R}^{q+m}$,
+  is close to $\mathbf{M}$ in terms of Hausdorff distance. After that, an estimator
+  $\mathbf{f}_{MLR}$ of the unknown function $\mathbf{f}$, mapping arbitrary input
+  $\mathbf{x}\in \mathbf{X}$ to output $\mathbf{f}_{MLR}(\mathbf{x})$, is constructed as
+  the solution to the equation $\mathbf{M}(\mathbf{f}_{MLR}) = \mathbf{M}_{MLR}$.
   Conformal prediction allows constructing a prediction region for an unknown output
-  $\mathbfy = \mathbff(\mathbfx)$ at Out-of-Sample input point $\mathbfx$ for a given
+  $\mathbf{y} = \mathbf{f}(\mathbf{x})$ at Out-of-Sample input point $\mathbf{x}$ for a given
   confidence level using given nonconformity measure, characterizing to which extent
-  an example $Z = (\mathbfx, \mathbfy)^\textrmT$ is different from examples in the
-  known dataset $\mathbfZ_(n)$. The paper proposes a new nonconformity measure based
-  on MLR estimator using an analog of Bregman distance.'
+  an example $Z = (\mathbf{x}, \mathbf{y})^{\mr{T}}$ is different from examples in the
+  known dataset $\mathbf{Z}_{(n)}$. The paper proposes a new nonconformity measure based
+  on MLR estimators using an analog of Bregman distance.'
 layout: inproceedings
 series: Proceedings of Machine Learning Research
 id: kuleshov18a

--- a/_posts/2018-06-07-kuleshov18a.md
+++ b/_posts/2018-06-07-kuleshov18a.md
@@ -6,10 +6,10 @@ abstract: 'The paper presents a geometrically motivated view on conformal predic
   is to estimate an unknown smooth mapping $\mathbf{f}$ from $q$-dimensional inputs
   $\mathbf{x}\in \mathbf{X}$ to $m$-dimensional outputs $\mathbf{y} = \mathbf{f}(\mathbf{x})$
   based on training dataset $\mathbf{Z}_{(n)}$ consisting of ``input-output'' pairs $\{Z_i
-  = (\mathbf{x}_i, \mathbf{y}_i = \mathbf{f}(\mathbf{x}_i))^{\mr{T}}, i = 1, 2, \ldots , n\}$.
+  = (\mathbf{x}_i, \mathbf{y}_i = \mathbf{f}(\mathbf{x}_i))^{\mathrm{T}}, i = 1, 2, \ldots , n\}$.
   Manifold Learning Regression (MLR) algorithm solves this task using Manifold learning
   technique. At first, unknown $q$-dimensional Regression manifold $\mathbf{M}(\mathbf{f})
-  = \{(\mathbf{x}, \mathbf{f}(\mathbf{x}))^{\mr{T}}\in\mathbb{R}^{q+m}: \mathbf{x}\in \mathbf{X}\subset \mathbb{R}^{q} \}$,
+  = \{(\mathbf{x}, \mathbf{f}(\mathbf{x}))^{\mathrm{T}}\in\mathbb{R}^{q+m}: \mathbf{x}\in \mathbf{X}\subset \mathbb{R}^{q} \}$,
   embedded in ambient $(q+m)$-dimensional space, is estimated from the training data
   $\mathbf{Z}_{(n)}$, sampled from this manifold. The constructed estimator $\mathbf{M}_{MLR}$,
   which is also $q$-dimensional manifold embedded in ambient space $\mathbb{R}^{q+m}$,
@@ -20,7 +20,7 @@ abstract: 'The paper presents a geometrically motivated view on conformal predic
   Conformal prediction allows constructing a prediction region for an unknown output
   $\mathbf{y} = \mathbf{f}(\mathbf{x})$ at Out-of-Sample input point $\mathbf{x}$ for a given
   confidence level using given nonconformity measure, characterizing to which extent
-  an example $Z = (\mathbf{x}, \mathbf{y})^{\mr{T}}$ is different from examples in the
+  an example $Z = (\mathbf{x}, \mathbf{y})^{\mathrm{T}}$ is different from examples in the
   known dataset $\mathbf{Z}_{(n)}$. The paper proposes a new nonconformity measure based
   on MLR estimators using an analog of Bregman distance.'
 layout: inproceedings


### PR DESCRIPTION
#### Summary of the Issue
This pull request addresses the issue of **misrendered abstract** on [kuleshov18a.html](http://proceedings.mlr.press/v91/kuleshov18a.html). The problem is in author's use of **LaTeX** macros which could not be fetched from the manuscript header by the LaTeX-HTML renderer used on that page.


#### Fix
The macros were **replaced with their definitions**: `\mb...` -> `\mathbf{...}` and `\mr...` -> `\mathrm{...}`. The PR also fixes a typo **singular/plural** in the last sentence.


#### Comments
@mreid, thank you for the comment over email.

I replaced the semi-converted markup in the markdown file with the original **LaTeX** abstract from the source of the manuscript kindly provided by the authors. This means that the rendered symbols of the `subset` (`\subset`) and `element of` (`\in`) as well as curly braces have been reverted to their original **LaTeX** commands.
